### PR TITLE
Add support for pkr.hcl and pkr.json formats

### DIFF
--- a/tfconfig/load.go
+++ b/tfconfig/load.go
@@ -127,6 +127,10 @@ func fileExt(path string) string {
 		return ".tf"
 	} else if strings.HasSuffix(path, ".tf.json") {
 		return ".tf.json"
+	} else if strings.HasSuffix(path, ".pkr.hcl") {
+		return ".pkr.hcl"
+	} else if strings.HasSuffix(path, ".pkr.json") {
+		return ".pkr.json"
 	} else {
 		return ""
 	}


### PR DESCRIPTION
Add ability to read Packer configuration files (`.pkr.hcl` and `pkr.json`), which in turn can be used by `terraform-docs` to generate documentation for Packer build configuration.

xref: https://github.com/terraform-docs/terraform-docs/issues/522