### PR TITLE
allow for provider declaration with index to be parsed.

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -293,6 +293,12 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 						if strDiags.HasErrors() {
 							traversal = nil
 						}
+					} else {
+						// Final fallback attempt to retrieve traversal expression, ignoring any index provided
+						absTraversals := attr.Expr.Variables()
+						if len(absTraversals) > 0 {
+							traversal = attr.Expr.Variables()[0]
+						}
 					}
 				}
 


### PR DESCRIPTION
I am aware of the statement that this repository does not accept external pull requests, but this addresses an issue with terraform-docs that cannot otherwise be resolved (as far as I can tell), so I am going to try just incase.

With the recent added support to `.tofu` files, it appears there is at least a limited desire to support OpenTofu. This update allows for a provider declaration on a resource or data source with an index to be specified, as was introduced with [OpenTofu v1.9.0](https://opentofu.org/docs/intro/whats-new/#provider-iteration-for_each). This fixes [issue 839](https://github.com/terraform-docs/terraform-docs/issues/839) opened on terraform-docs, and is the only way to do so as far as I can tell.

Please let me know if any additional activities are required on my part to make this acceptable.