### PR TITLE
Extend terraform-config-inspect to include OpenTofu metadata

### DIFF
--- a/tfconfig/load_hcl.go
+++ b/tfconfig/load_hcl.go
@@ -185,6 +185,24 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 				v.Sensitive = sensitive
 			}
 
+			if attr, defined := content.Attributes["ephemeral"]; defined {
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Ephemeral)
+				diags = append(diags, valDiags...)
+			}
+
+			for _, validationBlock := range content.Blocks {
+				validationContent, _, validationDiags := validationBlock.Body.PartialContent(validationSchema)
+				diags = append(diags, validationDiags...)
+				validation := &Validation{Pos: sourcePosHCL(validationBlock.DefRange)}
+				if attr, defined := validationContent.Attributes["condition"]; defined {
+					validation.Condition = string(attr.Expr.Range().SliceBytes(file.Bytes))
+				}
+				if attr, defined := validationContent.Attributes["error_message"]; defined {
+					validation.ErrorMessage = string(attr.Expr.Range().SliceBytes(file.Bytes))
+				}
+				v.Validations = append(v.Validations, validation)
+			}
+
 		case "output":
 
 			content, _, contentDiags := block.Body.PartialContent(outputSchema)
@@ -210,6 +228,11 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &sensitive)
 				diags = append(diags, valDiags...)
 				o.Sensitive = sensitive
+			}
+
+			if attr, defined := content.Attributes["ephemeral"]; defined {
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &o.Ephemeral)
+				diags = append(diags, valDiags...)
 			}
 
 		case "provider":
@@ -346,10 +369,10 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 			mod.ModuleCalls[name] = mc
 
 			if attr, defined := content.Attributes["source"]; defined {
-				var source string
-				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &source)
+				source, expression, valDiags := decodeStringExpression(attr, file)
 				diags = append(diags, valDiags...)
 				mc.Source = source
+				mc.SourceExpression = expression
 			}
 
 			if mc.Source == "" {
@@ -357,10 +380,10 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 			}
 
 			if attr, defined := content.Attributes["version"]; defined {
-				var version string
-				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &version)
+				version, expression, valDiags := decodeStringExpression(attr, file)
 				diags = append(diags, valDiags...)
 				mc.Version = version
+				mc.VersionExpression = expression
 			}
 
 		default:
@@ -371,4 +394,16 @@ func LoadModuleFromFile(file *hcl.File, mod *Module) hcl.Diagnostics {
 	}
 
 	return diags
+}
+
+func decodeStringExpression(attr *hcl.Attribute, file *hcl.File) (string, string, hcl.Diagnostics) {
+	_, evalDiags := attr.Expr.Value(nil)
+	if evalDiags.HasErrors() {
+		expression := strings.TrimSpace(string(attr.Expr.Range().SliceBytes(file.Bytes)))
+		return "", expression, nil
+	}
+
+	var value string
+	decodeDiags := gohcl.DecodeExpression(attr.Expr, nil, &value)
+	return value, "", decodeDiags
 }

--- a/tfconfig/module_call.go
+++ b/tfconfig/module_call.go
@@ -6,9 +6,11 @@ package tfconfig
 // ModuleCall represents a "module" block within a module. That is, a
 // declaration of a child module from inside its parent.
 type ModuleCall struct {
-	Name    string `json:"name"`
-	Source  string `json:"source"`
-	Version string `json:"version,omitempty"`
+	Name              string `json:"name"`
+	Source            string `json:"source"`
+	SourceExpression  string `json:"source_expression,omitempty"`
+	Version           string `json:"version,omitempty"`
+	VersionExpression string `json:"version_expression,omitempty"`
 
 	Pos SourcePos `json:"pos"`
 }

--- a/tfconfig/opentofu_test.go
+++ b/tfconfig/opentofu_test.go
@@ -1,0 +1,64 @@
+package tfconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadOpenTofuMetadata(t *testing.T) {
+	dir := t.TempDir()
+	config := `
+variable "token" {
+  type      = string
+  ephemeral = true
+
+  validation {
+    condition     = length(var.token) > 8
+    error_message = "token must be longer than eight characters"
+  }
+}
+
+output "token" {
+  value     = var.token
+  ephemeral = true
+}
+
+module "child" {
+  source  = local.module_source
+  version = var.module_version
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.tofu"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	module, diags := LoadModule(dir)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Error())
+	}
+
+	input := module.Variables["token"]
+	if !input.Ephemeral {
+		t.Error("expected variable to be ephemeral")
+	}
+	if len(input.Validations) != 1 {
+		t.Fatalf("expected one validation, got %d", len(input.Validations))
+	}
+	if got, want := input.Validations[0].Condition, "length(var.token) > 8"; got != want {
+		t.Errorf("condition = %q, want %q", got, want)
+	}
+	if got, want := input.Validations[0].ErrorMessage, `"token must be longer than eight characters"`; got != want {
+		t.Errorf("error message = %q, want %q", got, want)
+	}
+	if !module.Outputs["token"].Ephemeral {
+		t.Error("expected output to be ephemeral")
+	}
+	call := module.ModuleCalls["child"]
+	if got, want := call.SourceExpression, "local.module_source"; got != want {
+		t.Errorf("source expression = %q, want %q", got, want)
+	}
+	if got, want := call.VersionExpression, "var.module_version"; got != want {
+		t.Errorf("version expression = %q, want %q", got, want)
+	}
+}

--- a/tfconfig/output.go
+++ b/tfconfig/output.go
@@ -8,5 +8,6 @@ type Output struct {
 	Name        string    `json:"name"`
 	Description string    `json:"description,omitempty"`
 	Sensitive   bool      `json:"sensitive,omitempty"`
+	Ephemeral   bool      `json:"ephemeral,omitempty"`
 	Pos         SourcePos `json:"pos"`
 }

--- a/tfconfig/schema.go
+++ b/tfconfig/schema.go
@@ -78,8 +78,12 @@ var variableSchema = &hcl.BodySchema{
 		{
 			Name: "sensitive",
 		},
+		{Name: "ephemeral"},
 	},
+	Blocks: []hcl.BlockHeaderSchema{{Type: "validation"}},
 }
+
+var validationSchema = &hcl.BodySchema{Attributes: []hcl.AttributeSchema{{Name: "condition"}, {Name: "error_message"}}}
 
 var outputSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
@@ -89,6 +93,7 @@ var outputSchema = &hcl.BodySchema{
 		{
 			Name: "sensitive",
 		},
+		{Name: "ephemeral"},
 	},
 }
 

--- a/tfconfig/validation.go
+++ b/tfconfig/validation.go
@@ -1,0 +1,8 @@
+package tfconfig
+
+// Validation represents a validation block attached to a variable.
+type Validation struct {
+	Condition    string    `json:"condition"`
+	ErrorMessage string    `json:"error_message"`
+	Pos          SourcePos `json:"pos"`
+}

--- a/tfconfig/variable.go
+++ b/tfconfig/variable.go
@@ -13,9 +13,11 @@ type Variable struct {
 	// the native Go type system. The conversion from the value given in
 	// configuration may be slightly lossy. Only values that can be
 	// serialized by json.Marshal will be included here.
-	Default   interface{} `json:"default"`
-	Required  bool        `json:"required"`
-	Sensitive bool        `json:"sensitive,omitempty"`
+	Default     interface{}   `json:"default"`
+	Required    bool          `json:"required"`
+	Sensitive   bool          `json:"sensitive,omitempty"`
+	Ephemeral   bool          `json:"ephemeral,omitempty"`
+	Validations []*Validation `json:"validations,omitempty"`
 
 	Pos SourcePos `json:"pos"`
 }


### PR DESCRIPTION
Extend terraform-config-inspect to include OpenTofu

Adds:
- expression-based module source
- expression-based module version
- variable validation blocks
- ephemeral variables
- ephemeral outputs
- a focused parser test

Tested with:

$ go test ./...
?       github.com/terraform-docs/terraform-config-inspect      [no test files]
ok      github.com/terraform-docs/terraform-config-inspect/tfconfig     0.016s